### PR TITLE
Windows functionality Pull request for discussion.

### DIFF
--- a/gen_from_xml.rb
+++ b/gen_from_xml.rb
@@ -101,10 +101,6 @@ def generate_binding_impl(document)
   begin
     gl_commands = get_commands(document)
     gl_enums = get_enums(document)
-#	puts document
-#	gl_commands.each { |comm| puts comm.to_s }
-#	puts gl_commands.to_s
-#	puts gl_enums.to_s
 
     pull_feature = proc { |feature|
       feature_name = feature['name']

--- a/lib/opengl-core.rb
+++ b/lib/opengl-core.rb
@@ -11,6 +11,10 @@
 require 'opengl-core/gl-sym'
 require 'opengl-core/gl-enums'
 require 'opengl-core/gl-commands'
+require 'opengl-core/glx-enums'
+require 'opengl-core/glx-commands'
+require 'opengl-core/wgl-enums'
+require 'opengl-core/wgl-commands'
 
 
 module GL

--- a/lib/opengl-core/gl-sym.rb
+++ b/lib/opengl-core/gl-sym.rb
@@ -52,12 +52,9 @@ module GLSym
 
         if symfunc.nil?
 		  symfunc = self.loader.load_ext_sym(name, GL_COMMAND_TYPES[name])
-		  puts "func address: #{symfunc.ptr.to_i} abi: #{symfunc.abi}"
 		  if symfunc.ptr.to_i > -2 && symfunc.ptr.to_i < 5
           	raise NoMethodError, "GL function #{name} could not be loaded"
 		  end
-		else
-		  puts "func address: #{symfunc.ptr.to_i} abi: #{symfunc.abi}"
         end
 
         symfunc

--- a/lib/opengl-core/gl-sym.rb
+++ b/lib/opengl-core/gl-sym.rb
@@ -51,7 +51,13 @@ module GLSym
         symfunc = self.loader.load_sym(name, GL_COMMAND_TYPES[name])
 
         if symfunc.nil?
-          raise NoMethodError, "GL function #{name} could not be loaded"
+		  symfunc = self.loader.load_ext_sym(name, GL_COMMAND_TYPES[name])
+		  puts "func address: #{symfunc.ptr.to_i} abi: #{symfunc.abi}"
+		  if symfunc.ptr.to_i > -2 && symfunc.ptr.to_i < 5
+          	raise NoMethodError, "GL function #{name} could not be loaded"
+		  end
+		else
+		  puts "func address: #{symfunc.ptr.to_i} abi: #{symfunc.abi}"
         end
 
         symfunc

--- a/lib/opengl-core/gl-sym.rb
+++ b/lib/opengl-core/gl-sym.rb
@@ -51,10 +51,10 @@ module GLSym
         symfunc = self.loader.load_sym(name, GL_COMMAND_TYPES[name])
 
         if symfunc.nil?
-		  symfunc = self.loader.load_ext_sym(name, GL_COMMAND_TYPES[name])
-		  if symfunc.ptr.to_i > -2 && symfunc.ptr.to_i < 5
-          	raise NoMethodError, "GL function #{name} could not be loaded"
-		  end
+		      symfunc = self.loader.load_ext_sym(name, GL_COMMAND_TYPES[name])
+		      if symfunc.ptr.to_i > -2 && symfunc.ptr.to_i < 5
+         	  raise NoMethodError, "GL function #{name} could not be loaded"
+  	      end
         end
 
         symfunc

--- a/lib/opengl-core/gl-sym.rb
+++ b/lib/opengl-core/gl-sym.rb
@@ -51,10 +51,10 @@ module GLSym
         symfunc = self.loader.load_sym(name, GL_COMMAND_TYPES[name])
 
         if symfunc.nil?
-		      symfunc = self.loader.load_ext_sym(name, GL_COMMAND_TYPES[name])
-		      if symfunc.ptr.to_i > -2 && symfunc.ptr.to_i < 5
+          symfunc = self.loader.load_ext_sym(name, GL_COMMAND_TYPES[name])
+          if symfunc.ptr.to_i > -2 && symfunc.ptr.to_i < 5
          	  raise NoMethodError, "GL function #{name} could not be loaded"
-  	      end
+          end
         end
 
         symfunc

--- a/lib/opengl-core/gl-sym/fiddle-symbol-loader.rb
+++ b/lib/opengl-core/gl-sym/fiddle-symbol-loader.rb
@@ -17,9 +17,9 @@ module GL
 module GLSym
 
 class SymLoaderHash
-	extend Fiddle::Importer
-	@type_alias = {}
-	include Fiddle::Win32Types
+  extend Fiddle::Importer
+  @type_alias = {}
+  include Fiddle::Win32Types
 
   TYPE_MAPPINGS = {
     :'void'              => Fiddle::TYPE_VOID,
@@ -61,22 +61,21 @@ class SymLoaderHash
     :'GLDEBUGPROCKHR'    => Fiddle::TYPE_VOIDP,
     :'GLDEBUGPROCAMD'    => Fiddle::TYPE_VOIDP,
 
-		:'PROC'							 => Fiddle::TYPE_VOIDP,
-		:'HGLRC'						 => Fiddle::TYPE_VOIDP
-  	}
-	def self.[](key)
-		if TYPE_MAPPINGS.has_key?(key)
-			TYPE_MAPPINGS[key]
-		elsif key.to_s.end_with?('*')
-			TYPE_MAPPINGS[key] = Fiddle::TYPE_VOIDP
-		else
-			TYPE_MAPPINGS[key] = SymLoaderHash.parse_ctype key.to_s, @type_alias
-#			raise ArgumentError, "No type mapping defined for #{key}"
-		end
-	end
-	def self.[]=(key, val)
-		TYPE_MAPPINGS[key] = val
-	end
+    :'PROC'              => Fiddle::TYPE_VOIDP,
+    :'HGLRC'             => Fiddle::TYPE_VOIDP
+    }
+    def self.[](key)
+      if TYPE_MAPPINGS.has_key?(key)
+        TYPE_MAPPINGS[key]
+      elsif key.to_s.end_with?('*')
+        TYPE_MAPPINGS[key] = Fiddle::TYPE_VOIDP
+      else
+        TYPE_MAPPINGS[key] = SymLoaderHash.parse_ctype key.to_s, @type_alias	#parse_ctype Raises an error on "unsupported type"
+      end
+    end
+    def self.[]=(key, val)
+      TYPE_MAPPINGS[key] = val
+    end
 end
 class FiddleSymbolLoader
 
@@ -153,13 +152,14 @@ class FiddleSymbolLoader
 
     begin
       sym = @opengl_lib[name.to_s]
+
       Fiddle::Function.new(
         sym,
         fiddle_typed(types[:parameter_types]),
         fiddle_typed(types[:return_type])
         )
     rescue Fiddle::DLError
-			nil
+      nil
     end if @opengl_lib
   end
 

--- a/lib/opengl-core/gl-sym/fiddle-symbol-loader.rb
+++ b/lib/opengl-core/gl-sym/fiddle-symbol-loader.rb
@@ -17,9 +17,9 @@ module GL
 module GLSym
 
 class SymLoaderHash
-	extend Fiddle::Importer
-	@type_alias = {}
-	include Fiddle::Win32Types
+  extend Fiddle::Importer
+  @type_alias = {}
+  include Fiddle::Win32Types
 
   TYPE_MAPPINGS = {
     :'void'              => Fiddle::TYPE_VOID,
@@ -61,22 +61,21 @@ class SymLoaderHash
     :'GLDEBUGPROCKHR'    => Fiddle::TYPE_VOIDP,
     :'GLDEBUGPROCAMD'    => Fiddle::TYPE_VOIDP,
 
-		:'PROC'							 => Fiddle::TYPE_VOIDP,
-		:'HGLRC'						 => Fiddle::TYPE_VOIDP
-  	}
-	def self.[](key)
-		if TYPE_MAPPINGS.has_key?(key)
-			TYPE_MAPPINGS[key]
-		elsif key.to_s.end_with?('*')
-			TYPE_MAPPINGS[key] = Fiddle::TYPE_VOIDP
-		else
-			TYPE_MAPPINGS[key] = SymLoaderHash.parse_ctype key.to_s, @type_alias
-#			raise ArgumentError, "No type mapping defined for #{key}"
-		end
-	end
-	def self.[]=(key, val)
-		TYPE_MAPPINGS[key] = val
-	end
+    :'PROC'              => Fiddle::TYPE_VOIDP,
+    :'HGLRC'             => Fiddle::TYPE_VOIDP
+    }
+    def self.[](key)
+      if TYPE_MAPPINGS.has_key?(key)
+        TYPE_MAPPINGS[key]
+      elsif key.to_s.end_with?('*')
+        TYPE_MAPPINGS[key] = Fiddle::TYPE_VOIDP
+      else
+        TYPE_MAPPINGS[key] = SymLoaderHash.parse_ctype key.to_s, @type_alias	#parse_ctype Raises an error on "unsupported type"
+      end
+    end
+    def self.[]=(key, val)
+      TYPE_MAPPINGS[key] = val
+    end
 end
 class FiddleSymbolLoader
 
@@ -128,49 +127,50 @@ class FiddleSymbolLoader
           raise 'Unrecognized platform'
         end
 
-			getProcAddressName =
-				case host
+        getProcAddressName =
+        case host
         when %r[ mac\sos | darwin ]ix
-					:aglGetProcAddress
+          :aglGetProcAddress
         when %r[ mswin | msys | mingw | cygwin | bcwin | wince | emc ]ix
-					:wglGetProcAddress
+          :wglGetProcAddress
         when %r[ linux | solaris | bsd]ix
-					:glXGetProcAddress
+          :glXGetProcAddress
         else
           raise 'Unrecognized platform'
         end
 
       @opengl_lib = Fiddle.dlopen(lib_path)
-			getProcAddress = @opengl_lib[getProcAddressName.to_s]
+      getProcAddress = @opengl_lib[getProcAddressName.to_s]
 
 
-    @glGetProcAddress = Fiddle::Function.new( 
-				getProcAddress, 
-				fiddle_typed(GL_COMMAND_TYPES[getProcAddressName][:parameter_types]),
-				fiddle_typed(GL_COMMAND_TYPES[getProcAddressName][:return_type])
-				)
+      @glGetProcAddress = Fiddle::Function.new( 
+        getProcAddress, 
+        fiddle_typed(GL_COMMAND_TYPES[getProcAddressName][:parameter_types]),
+        fiddle_typed(GL_COMMAND_TYPES[getProcAddressName][:return_type])
+        )
     end
 
     begin
       sym = @opengl_lib[name.to_s]
+
       Fiddle::Function.new(
         sym,
         fiddle_typed(types[:parameter_types]),
         fiddle_typed(types[:return_type])
         )
     rescue Fiddle::DLError
-			nil
+      nil
     end if @opengl_lib
   end
 
-	def load_ext_sym(name, types)
-		sym = @glGetProcAddress.call(name.to_s)
-		Fiddle::Function.new(
-			sym,
-			fiddle_typed(types[:parameter_types]),
-			fiddle_typed(types[:return_type])
-		)
-	end
+  def load_ext_sym(name, types)
+    sym = @glGetProcAddress.call(name.to_s)
+    Fiddle::Function.new(
+      sym,
+      fiddle_typed(types[:parameter_types]),
+      fiddle_typed(types[:return_type])
+    )
+  end
 
 end # FiddleSymbolLoader
 

--- a/lib/opengl-core/gl-sym/fiddle-symbol-loader.rb
+++ b/lib/opengl-core/gl-sym/fiddle-symbol-loader.rb
@@ -88,7 +88,7 @@ class FiddleSymbolLoader
   end
 
   def initialize
-    @opengl_lib = nil
+    @opengl_lib = Fiddle::dlopen('opengl32.dll')
 		@glGetProcAddress = nil
     @loaded = {}
   end
@@ -149,14 +149,10 @@ class FiddleSymbolLoader
 				fiddle_typed(GL_COMMAND_TYPES[getProcAddressName][:parameter_types]),
 				fiddle_typed(GL_COMMAND_TYPES[getProcAddressName][:return_type])
 				)
-		puts "#{getProcAddressName.to_s}: #{@glGetProcAddress.ptr}"
     end
 
     begin
-puts "#{name.to_s}: #{fiddle_typed(types[:parameter_types]).to_s}, #{fiddle_typed(types[:return_type]).to_s}"
-
       sym = @opengl_lib[name.to_s]
-			puts "sym: #{sym}"
       Fiddle::Function.new(
         sym,
         fiddle_typed(types[:parameter_types]),


### PR DESCRIPTION
Synopsis:
  -First two commits were base changes for binding generation and the type mapping.
  -Third commit was fixing everything I broke in the first two commits.
  -Fourth commit was removing debug messages and changing the @opengl_lib default value.

I'm not saying this should be pulled as is, I'm not pleased that I changed the structure of fiddle-symbol-loader.rb but Hash's default_proc being a block/proc I couldn't call Fiddle::CParser::parse_ctype from within it due to context/scoping issues.

Windows is restricted to opengl 1.1 functionality if you are calling functions solely from opengl32.dll.
This change essentailly bakes in wglGetProcAddress lookups for functions that aren't found in opengl32.dll
I did throw it in a switch though so aglGetProcAddress lookups are automatic on Macs and glXGetProcAddress lookups are automatic on Linux machines.  These are not tested though and I don't know that any agl calls are listed in the opengl spec xmls I extended it to use as well.

Anyways, thanks for doing all the work to get it to the state that its currently in.  If you think its fine I'm fine if you accept the pull request as is, I just didn't want you to feel obligated haha.
